### PR TITLE
Laravel 7 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
   "require": {
     "php": ">=7.1.3",
     "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
-    "illuminate/support": "~6.0|^5.5",
-    "illuminate/routing": "~6.0|^5.5"
+    "illuminate/support": "~7.0|~6.0|^5.5",
+    "illuminate/routing": "~7.0|~6.0|^5.5"
   },
   "require-dev": {
     "phpunit/phpunit": "~7.0",


### PR DESCRIPTION
Simply updating the Illuminate package dependencies to allow for compatibility with Laravel 7.x.