### PR TITLE
Laravel 8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
   ],
   "require": {
     "php": ">=7.1.3",
-    "guzzlehttp/guzzle": "~6.0|~5.0|~4.0",
-    "illuminate/support": "~7.0|~6.0|^5.5",
-    "illuminate/routing": "~7.0|~6.0|^5.5"
+    "guzzlehttp/guzzle": "~7.0|~6.0|~5.0|~4.0",
+    "illuminate/support": "~8.0|~7.0|~6.0|^5.5",
+    "illuminate/routing": "~8.0|~7.0|~6.0|^5.5"
   },
   "require-dev": {
     "phpunit/phpunit": "~7.0",


### PR DESCRIPTION
Pretty straightforward, just updating dependencies to allow for upgraded Illuminate and Guzzle packages needed to support Laravel 8.