### PR TITLE
Checkr API Updates 2022

### DIFF
--- a/src/Entities/Resources/Report.php
+++ b/src/Entities/Resources/Report.php
@@ -20,4 +20,24 @@ class Report extends AbstractResource
     {
         parent::__construct($values, $client);
     }
+
+    /**
+     * Complete an existing report.
+     *
+     * @return $this
+     */
+    public function complete()
+    {
+        $path = $this->processPath('reports/:report_id/complete', ['report_id' => $this->getAttribute('id')]);
+        $response = $this->completeRequest($path);
+        $this->setAttributes([]);
+        $this->setValues($response);
+
+        return $this;
+    }
+
+    protected function completeRequest($path)
+    {
+        return $this->getClient()->request('post', $path);
+    }
 }

--- a/src/Laravel/Events/CandidatePostAdverseAction.php
+++ b/src/Laravel/Events/CandidatePostAdverseAction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class CandidatePostAdverseAction
+{
+    public $candidatePostAdverseAction;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $candidatePostAdverseAction
+     */
+    public function __construct($candidatePostAdverseAction)
+    {
+        $this->candidatePostAdverseAction = $candidatePostAdverseAction;
+    }
+}

--- a/src/Laravel/Events/CandidatePreAdverseAction.php
+++ b/src/Laravel/Events/CandidatePreAdverseAction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class CandidatePreAdverseAction
+{
+    public $candidatePreAdverseAction;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $candidatePreAdverseAction
+     */
+    public function __construct($candidatePreAdverseAction)
+    {
+        $this->candidatePreAdverseAction = $candidatePreAdverseAction;
+    }
+}

--- a/src/Laravel/Events/CandidateUpdated.php
+++ b/src/Laravel/Events/CandidateUpdated.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class CandidateUpdated
+{
+    public $candidateUpdated;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $candidateUpdated
+     */
+    public function __construct($candidateUpdated)
+    {
+        $this->candidateUpdated = $candidateUpdated;
+    }
+}

--- a/src/Laravel/Events/ContinuousCheckConfirmationRequired.php
+++ b/src/Laravel/Events/ContinuousCheckConfirmationRequired.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class ContinuousCheckConfirmationRequired
+{
+    public $continuousCheckConfirmationRequired;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $continuousCheckConfirmationRequired
+     */
+    public function __construct($continuousCheckConfirmationRequired)
+    {
+        $this->continuousCheckConfirmationRequired = $continuousCheckConfirmationRequired;
+    }
+}

--- a/src/Laravel/Events/ContinuousCheckSubscriptionError.php
+++ b/src/Laravel/Events/ContinuousCheckSubscriptionError.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class ContinuousCheckSubscriptionError
+{
+    public $continuousCheckSubscriptionError;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $continuousCheckSubscriptionError
+     */
+    public function __construct($continuousCheckSubscriptionError)
+    {
+        $this->continuousCheckSubscriptionError = $continuousCheckSubscriptionError;
+    }
+}

--- a/src/Laravel/Events/InvitationDeleted.php
+++ b/src/Laravel/Events/InvitationDeleted.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class InvitationDeleted
+{
+    public $invitationDeleted;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $invitationDeleted
+     */
+    public function __construct($invitationDeleted)
+    {
+        $this->invitationDeleted = $invitationDeleted;
+    }
+}

--- a/src/Laravel/Events/PackageCreated.php
+++ b/src/Laravel/Events/PackageCreated.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class PackageCreated
+{
+    public $packageCreated;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $packageCreated
+     */
+    public function __construct($packageCreated)
+    {
+        $this->packageCreated = $packageCreated;
+    }
+}

--- a/src/Laravel/Events/PackageDeleted.php
+++ b/src/Laravel/Events/PackageDeleted.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class PackageDeleted
+{
+    public $packageDeleted;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $packageDeleted
+     */
+    public function __construct($packageDeleted)
+    {
+        $this->packageDeleted = $packageDeleted;
+    }
+}

--- a/src/Laravel/Events/PackageUpdated.php
+++ b/src/Laravel/Events/PackageUpdated.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class PackageUpdated
+{
+    public $packageUpdated;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $packageUpdated
+     */
+    public function __construct($packageUpdated)
+    {
+        $this->packageUpdated = $packageUpdated;
+    }
+}

--- a/src/Laravel/Events/ReportCanceled.php
+++ b/src/Laravel/Events/ReportCanceled.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class ReportCanceled
+{
+    public $reportCanceled;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $reportCanceled
+     */
+    public function __construct($reportCanceled)
+    {
+        $this->reportCanceled = $reportCanceled;
+    }
+}

--- a/src/Laravel/Events/ReportUpdated.php
+++ b/src/Laravel/Events/ReportUpdated.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class ReportUpdated
+{
+    public $reportUpdated;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $reportUpdated
+     */
+    public function __construct($reportUpdated)
+    {
+        $this->reportUpdated = $reportUpdated;
+    }
+}

--- a/src/Laravel/Events/VerificationCompleted.php
+++ b/src/Laravel/Events/VerificationCompleted.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class VerificationCompleted
+{
+    public $verificationCompleted;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $verificationCompleted
+     */
+    public function __construct($verificationCompleted)
+    {
+        $this->verificationCompleted = $verificationCompleted;
+    }
+}

--- a/src/Laravel/Events/VerificationCreated.php
+++ b/src/Laravel/Events/VerificationCreated.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class VerificationCreated
+{
+    public $verificationCreated;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $verificationCreated
+     */
+    public function __construct($verificationCreated)
+    {
+        $this->verificationCreated = $verificationCreated;
+    }
+}

--- a/src/Laravel/Events/VerificationProcessed.php
+++ b/src/Laravel/Events/VerificationProcessed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Lyal\Checkr\Laravel\Events;
+
+class VerificationProcessed
+{
+    public $verificationProcessed;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param \stdClass $verificationProcessed
+     */
+    public function __construct($verificationProcessed)
+    {
+        $this->verificationProcessed = $verificationProcessed;
+    }
+}


### PR DESCRIPTION
Based on the [report lifecycle enhancements](https://info.checkr.com/rs/204-WFI-586/images/Report%20Lifecycle%20Design%20Decisions%20Checklist.pdf) that Checkr intends to release this year, this PR adds some missing webhook event types and implements the newly added report completion API. Note that the `Report` completion logic is based heavily on a similar custom API call found in the `Document` resource entity class.

Other changes listed by Checkr include retrieving specific `Screening` objects by ID, which is already supported in this package by nature of the `AbstractEntity` class including the generic `Getable` trait.